### PR TITLE
Remove need for private messages

### DIFF
--- a/discord/src/main/java/com/gmail/chickenpowerrr/ranksync/discord/command/LinkCommand.java
+++ b/discord/src/main/java/com/gmail/chickenpowerrr/ranksync/discord/command/LinkCommand.java
@@ -5,16 +5,10 @@ import com.gmail.chickenpowerrr.ranksync.api.command.Command;
 import com.gmail.chickenpowerrr.ranksync.api.event.PlayerLinkCodeCreateEvent;
 import com.gmail.chickenpowerrr.ranksync.api.player.Player;
 import com.gmail.chickenpowerrr.ranksync.discord.language.Translation;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.Timer;
-import java.util.TimerTask;
-import java.util.stream.Collectors;
 import lombok.Getter;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * This class represents the Discord !link command, it can be used to link a Discord account to
@@ -25,120 +19,107 @@ import lombok.Getter;
  */
 public class LinkCommand implements Command {
 
-  private static final Random random = new Random();
+    private static final Random random = new Random();
 
-  @Getter
-  private final String label;
-  private final Collection<String> aliases;
+    @Getter
+    private final String label;
+    private final Collection<String> aliases;
 
-  private final Map<String, Long> timeOuts = new HashMap<>();
+    private final Map<String, Long> timeOuts = new HashMap<>();
 
-  /**
-   * Starts a timer that deletes codes that haven't been used after five minutes
-   *
-   * @param label the label of the command ('link')
-   * @param aliases all aliases that, besides the name can get used to invoke this command
-   */
-  public LinkCommand(String label, Collection<String> aliases) {
-    this.label = label;
-    this.aliases = aliases;
+    /**
+     * Starts a timer that deletes codes that haven't been used after five minutes
+     *
+     * @param label   the label of the command ('link')
+     * @param aliases all aliases that, besides the name can get used to invoke this command
+     */
+    public LinkCommand(String label, Collection<String> aliases) {
+        this.label = label;
+        this.aliases = aliases;
 
-    new Timer().scheduleAtFixedRate(new TimerTask() {
+        new Timer().scheduleAtFixedRate(new TimerTask() {
 
-      @Override
-      public void run() {
-        Collection<String> toRemove = timeOuts.entrySet().stream()
-            .filter(entry -> entry.getValue() + 1000 * 60 * 5 < System.currentTimeMillis())
-            .map(Map.Entry::getKey).collect(Collectors.toSet());
-        toRemove.forEach(timeOuts::remove);
-      }
-    }, 1000 * 10, 1000 * 10);
-  }
-
-  /**
-   * Links the account of a Discord user if it hasn't been linked already
-   *
-   * @param invoker the Discord user that invokes the command
-   * @param arguments should be empty for this command
-   * @return the message that will be send into the channel where the command was executed
-   */
-  @Override
-  public String execute(Player invoker, List<String> arguments) {
-    if (invoker.getUuid() == null) {
-      if (!onCooldown(invoker.getPersonalId())) {
-        String secretKey = randomString(10 + random.nextInt(2));
-        RankSyncApi.getApi().execute(new PlayerLinkCodeCreateEvent(invoker, secretKey));
-
-        if (invoker.sendPrivateMessage(
-            Translation.LINK_COMMAND_PRIVATE
-                .getTranslation("name", invoker.getFancyName(), "key", secretKey))) {
-          this.timeOuts.put(invoker.getPersonalId(), System.currentTimeMillis());
-          return Translation.LINK_COMMAND_PUBLIC.getTranslation("name", invoker.getFancyName());
-        } else {
-          return Translation.LINK_COMMAND_ENABLE_PRIVATE_MESSAGES
-              .getTranslation("name", invoker.getFancyName());
-        }
-      } else {
-        if (invoker.sendPrivateMessage(Translation.LINK_COMMAND_RIGHTTHERE.getTranslation())) {
-          return Translation.LINK_COMMAND_REQUEST_LIMIT
-              .getTranslation("name", invoker.getFancyName());
-        } else {
-          return Translation.LINK_COMMAND_ENABLE_PRIVATE_MESSAGES
-              .getTranslation("name", invoker.getFancyName());
-        }
-      }
-    } else {
-      return Translation.LINK_COMMAND_ALREADY_LINKED.getTranslation("name", invoker.getFancyName());
+            @Override
+            public void run() {
+                Collection<String> toRemove = timeOuts.entrySet().stream()
+                        .filter(entry -> entry.getValue() + 1000 * 60 * 5 < System.currentTimeMillis())
+                        .map(Map.Entry::getKey).collect(Collectors.toSet());
+                toRemove.forEach(timeOuts::remove);
+            }
+        }, 1000 * 10, 1000 * 10);
     }
-  }
 
-  /**
-   * Returns if the user is still on cooldown
-   *
-   * @param identifier the identifier of the Discord user
-   * @return if the user is still on cooldown
-   */
-  private boolean onCooldown(String identifier) {
-    return this.timeOuts.containsKey(identifier)
-        && this.timeOuts.get(identifier) + 1000 * 60 * 5 >= System.currentTimeMillis();
-  }
+    /**
+     * Links the account of a Discord user if it hasn't been linked already
+     *
+     * @param invoker   the Discord user that invokes the command
+     * @param arguments should be empty for this command
+     * @return the message that will be send into the channel where the command was executed
+     */
+    @Override
+    public String execute(Player invoker, List<String> arguments) {
+        if (invoker.getUuid() == null) {
+            if (!onCooldown(invoker.getPersonalId())) {
+                String secretKey = randomString(10 + random.nextInt(2));
+                RankSyncApi.getApi().execute(new PlayerLinkCodeCreateEvent(invoker, secretKey));
 
-  /**
-   * Returns true because everyone can link their account
-   *
-   * @param player the player who wants to link their Discord account
-   * @return true
-   */
-  @Override
-  public boolean hasPermission(Player player) {
-    return true;
-  }
-
-  @Override
-  public Collection<String> getAliases() {
-    return Collections.unmodifiableCollection(this.aliases);
-  }
-
-  /**
-   * Returns a random String with the given size
-   *
-   * @param size the amount of characters in the String
-   * @return a random String with the requested size
-   */
-  private String randomString(int size) {
-    StringBuilder stringBuilder = new StringBuilder();
-    for (int i = 0; i < size; i++) {
-      stringBuilder.append(randomChar());
+              return  Translation.LINK_COMMAND_PRIVATE
+                      .getTranslation("name", invoker.getFancyName(), "key", secretKey);
+            } else {
+              return Translation.LINK_COMMAND_RIGHTTHERE.getTranslation();
+            }
+        } else {
+            return Translation.LINK_COMMAND_ALREADY_LINKED.getTranslation("name", invoker.getFancyName());
+        }
     }
-    return stringBuilder.toString();
-  }
 
-  /**
-   * Returns a random character
-   */
-  private char randomChar() {
-    int randomNumber = random.nextInt(52);
-    char base = (randomNumber < 26) ? 'A' : 'a';
-    return (char) (base + randomNumber % 26);
-  }
+    /**
+     * Returns if the user is still on cooldown
+     *
+     * @param identifier the identifier of the Discord user
+     * @return if the user is still on cooldown
+     */
+    private boolean onCooldown(String identifier) {
+        return this.timeOuts.containsKey(identifier)
+                && this.timeOuts.get(identifier) + 1000 * 60 * 5 >= System.currentTimeMillis();
+    }
+
+    /**
+     * Returns true because everyone can link their account
+     *
+     * @param player the player who wants to link their Discord account
+     * @return true
+     */
+    @Override
+    public boolean hasPermission(Player player) {
+        return true;
+    }
+
+    @Override
+    public Collection<String> getAliases() {
+        return Collections.unmodifiableCollection(this.aliases);
+    }
+
+    /**
+     * Returns a random String with the given size
+     *
+     * @param size the amount of characters in the String
+     * @return a random String with the requested size
+     */
+    private String randomString(int size) {
+        StringBuilder stringBuilder = new StringBuilder();
+        for (int i = 0; i < size; i++) {
+            stringBuilder.append(randomChar());
+        }
+        return stringBuilder.toString();
+    }
+
+    /**
+     * Returns a random character
+     */
+    private char randomChar() {
+        int randomNumber = random.nextInt(52);
+        char base = (randomNumber < 26) ? 'A' : 'a';
+        return (char) (base + randomNumber % 26);
+    }
 }

--- a/spigot/pom.xml
+++ b/spigot/pom.xml
@@ -16,7 +16,7 @@
   <repositories>
     <repository>
       <id>vault-repo</id>
-      <url>http://nexus.hc.to/content/repositories/pub_releases</url>
+      <url>https://nexus.hc.to/content/repositories/pub_releases</url>
     </repository>
 
     <repository>

--- a/spigot/pom.xml
+++ b/spigot/pom.xml
@@ -15,6 +15,11 @@
 
   <repositories>
     <repository>
+      <id>spigot-repo</id>
+      <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+    </repository>
+
+    <repository>
       <id>vault-repo</id>
       <url>https://nexus.hc.to/content/repositories/pub_releases</url>
     </repository>


### PR DESCRIPTION
Implemented Discord's ephemeral messages to make things easier for users, they no longer need to enable private messages.
![image](https://user-images.githubusercontent.com/38576621/191786935-35f5960b-0b0e-4962-a5a8-2546c71891f9.png)

I've also added the spigot repo to maven, so it gets the artifact from there instead of maven local.